### PR TITLE
Fix ukey computation

### DIFF
--- a/swiftspec/core.py
+++ b/swiftspec/core.py
@@ -307,7 +307,7 @@ class SWIFTFileSystem(AsyncFileSystem):
         )
 
     def ukey(self, path):
-        return tokenize(path, self.kwargs, self.info(path)["hash"])
+        return tokenize(path, self.info(path).get("hash", "-"))
 
     async def _info(self, path, **kwargs):
         ref = SWIFTRef(path)

--- a/swiftspec/core.py
+++ b/swiftspec/core.py
@@ -307,7 +307,7 @@ class SWIFTFileSystem(AsyncFileSystem):
         )
 
     def ukey(self, path):
-        return tokenize(path, self.kwargs, self.info(path)["ETag"])
+        return tokenize(path, self.kwargs, self.info(path)["hash"])
 
     async def _info(self, path, **kwargs):
         ref = SWIFTRef(path)
@@ -326,6 +326,6 @@ class SWIFTFileSystem(AsyncFileSystem):
                 "name": ref.swift_url,
                 "type": "file",
                 "size": int(res.headers["Content-Length"]),
-                "Etag": res.headers["Etag"],
+                "hash": res.headers["Etag"],
             }
         return info

--- a/test/test_swiftfilesystem.py
+++ b/test/test_swiftfilesystem.py
@@ -102,6 +102,7 @@ def create_mock_data():
         "a1": {
             "c1": {
                 "hello": b"Hello World",
+                "hello2": b"Hello World2",
             },
         }
     }
@@ -227,7 +228,7 @@ def test_ls_account(fs):
 
 def test_ls_container(fs):
     res = fs.ls("swift://server/a1/c1")
-    assert len(res) == 1
+    assert len(res) == 2
     assert res[0]["name"] == "swift://server/a1/c1/hello"
     assert res[0]["type"] == "file"
     assert res[0]["size"] == len(b"Hello World")
@@ -323,3 +324,14 @@ def test_open_write(fs):
     with fs.open("swift://server/a1/c1/w", "wb") as f:
         f.write(b"write test")
     assert fs._session.store["a1"]["c1"]["w"] == b"write test"
+
+
+def test_ukey(fs):
+    assert fs.ukey("swift://server/a1/c1/hello") != fs.ukey(
+        "swift://server/a1/c1/hello2"
+    )
+    assert fs.ukey("swift://server/a1/c1/hello") != fs.ukey("swift://server/a1/c1")
+    oldkey = fs.ukey("swift://server/a1/c1/hello")
+    fs.pipe("swift://server/a1/c1/hello", b"test")
+    newkey = fs.ukey("swift://server/a1/c1/hello")
+    assert oldkey != newkey


### PR DESCRIPTION
The computation of `ukey` was broken for several reasons:

* we don't (currently) need to include any `kwargs` in the computation, the path fully determines the object
* there was an inconsistency between using `hash` and `Etag` in the `info` dict
* (pseudo-) directories don't have a hash / Etag etc.. on the server, so we can't rely on having them

This PR fixes these issues and adds a test for it.